### PR TITLE
Added MaxWords validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The following validation rules are currently available:
 | Domain                | validation.domain                 | Requires that the given value be a domain e.g. google.com, www.google.com                                             |
 | CitizenIdentification | validation.citizen_identification | Requires that the given value be a citizen identification number of USA, UK, France or Brazil (see class for details) |
 | WithoutWhitespace     | validation.without_whitespace     | Requires that the given value not include any whitespace characters                                                   |
+| MaxWords              | validation.max_words              | Requires that the given value cannot contains more words than the specified - see class for details                   |
 
 ## Contributing
 

--- a/src/Rules/MaxWords.php
+++ b/src/Rules/MaxWords.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace Axiom\Rules;
+
+use Axiom\Types\Rule;
+
+class MaxWords extends Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     **/
+    public function passes($attribute, $value) : bool
+    {
+        return count(preg_split('~[^\p{L}\p{N}\']+~u',$value)) <= $this->parameters[0];
+    }
+
+
+
+    /**
+     * Get the validation error message.
+     *
+     **/
+    public function message() : string
+    {
+        return $this->getLocalizedErrorMessage(
+            'max_words',
+            'The :attribute cannot be longer than ' . $this->parameters[0] . ' words.'
+        );
+    }
+
+}

--- a/tests/MaxWordsTest.php
+++ b/tests/MaxWordsTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Axiom\Rules\Tests;
+
+use Axiom\Rules\MaxWords;
+use Orchestra\Testbench\TestCase;
+
+class MaxWordsTest extends TestCase
+{
+
+    /**
+     * @test
+     * @dataProvider provideSentences
+     */
+    public function the_max_words_rule_can_be_validated($data)
+    {
+        $rule = ['text' => [new MaxWords($data['max_words'])]];
+        $this->assertEquals($data['passes'], validator(['text' => $data['text']], $rule)->passes());
+    }
+
+    function provideSentences()
+    {
+        return [
+            [
+                ['text' => 'hello world', 'max_words' => 2, 'passes' => true]
+            ],
+            [
+                ['text' => 'مرحبا بالعالم', 'max_words' => 2, 'passes' => true]
+            ],
+            [
+                ['text' => 'This sentence contains more than 2 words', 'max_words' => 2, 'passes' => false]
+            ],
+            [
+                ['text' => 'Three words sentence', 'max_words' => 3, 'passes' => true]
+            ],
+            [
+                ['text' => 'مرحبا بالعالم من التحقق', 'max_words' => 3, 'passes' => false]
+            ],
+        ];
+    }
+
+}


### PR DESCRIPTION
Hello! I added a validation rule to check for a max number of words. 

I tried to do it so it will work with more charsets than the traditional str_word_count supports.

Thats why I used this: `count(preg_split('~[^\p{L}\p{N}\']+~u',$value))`