### PR TITLE
Added hex-color rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following validation rules are currently available:
 | CitizenIdentification | validation.citizen_identification | Requires that the given value be a citizen identification number of USA, UK, France or Brazil (see class for details) |
 | WithoutWhitespace     | validation.without_whitespace     | Requires that the given value not include any whitespace characters                                                   |
 | MaxWords              | validation.max_words              | Requires that the given value cannot contain more words than specified                                                |
+| HexColor              | validation.hex_color              | Requires that the given value is a valid hex color eg. #fff, #0f0f0f, #00ff0080                                       |
 
 ## Contributing
 

--- a/src/Rules/HexColor.php
+++ b/src/Rules/HexColor.php
@@ -6,23 +6,41 @@ use Axiom\Types\Rule;
 
 class HexColor extends Rule
 {
-    private array $pregMatchArray = [
+    /**
+     * Hex color regex formats.
+     *
+     * @var array
+     */
+    private array $formats = [
         4 => '/^#([a-fA-F0-9]{3})$/i',
         7 => '/^#([a-fA-F0-9]{6})$/i',
-        9 => '/^#([a-fA-F0-9]{8})$/i',
+        9 => '/^#([a-fA-F0-9]{6}[0-9]{2})$/i',
     ];
 
+    /**
+     * Determines if the rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     *
+     * @return bool
+     */
     public function passes($attribute, $value)
     {
-        if (! is_string($value) || ! in_array(strlen($value), array_keys($this->pregMatchArray))) {
+        if (! is_string($value) || ! in_array(strlen($value), array_keys($this->formats))) {
             return false;
         }
 
-        $match = preg_match($this->pregMatchArray[strlen($value)], $value);
+        $match = preg_match($this->formats[strlen($value)], $value);
 
         return $match > 0;
     }
 
+    /**
+     * Message returned on validation failure.
+     *
+     * @return array|string
+     */
     public function message()
     {
         return $this->getLocalizedErrorMessage(

--- a/src/Rules/HexColor.php
+++ b/src/Rules/HexColor.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Axiom\Rules;
+
+use Axiom\Types\Rule;
+
+class HexColor extends Rule
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function passes($attribute, $value)
+    {
+        return preg_match('/^#([a-fA-F0-9]{6})$/i', $value) > 0;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function message()
+    {
+        return $this->getLocalizedErrorMessage(
+            'hex_color',
+            'The :attribute has to be a valid hex color.'
+        );
+    }
+}

--- a/src/Rules/HexColor.php
+++ b/src/Rules/HexColor.php
@@ -6,18 +6,23 @@ use Axiom\Types\Rule;
 
 class HexColor extends Rule
 {
+    private array $pregMatchArray = [
+        4 => '/^#([a-fA-F0-9]{3})$/i',
+        7 => '/^#([a-fA-F0-9]{6})$/i',
+        9 => '/^#([a-fA-F0-9]{8})$/i',
+    ];
 
-    /**
-     * @inheritDoc
-     */
     public function passes($attribute, $value)
     {
-        return preg_match('/^#([a-fA-F0-9]{6})$/i', $value) > 0;
+        if (! is_string($value) || ! in_array(strlen($value), array_keys($this->pregMatchArray))) {
+            return false;
+        }
+
+        $match = preg_match($this->pregMatchArray[strlen($value)], $value);
+
+        return $match > 0;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function message()
     {
         return $this->getLocalizedErrorMessage(

--- a/tests/HexColorTest.php
+++ b/tests/HexColorTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Axiom\Rules\Tests;
+
+use Axiom\Rules\HexColor;
+use Orchestra\Testbench\TestCase;
+
+class HexColorTest extends TestCase
+{
+    /** @test */
+    public function it_can_validate_hex_color()
+    {
+        $rule = ['hex_color' => [new HexColor()]];
+
+        $this->assertTrue(validator(['hex_color' => '#f0f0f0'], $rule)->passes());
+        $this->assertFalse(validator(['hex_color' => '#f0f0f0ff'], $rule)->passes());
+        $this->assertFalse(validator(['hex_color' => 'f0f0f0'], $rule)->passes());
+        $this->assertFalse(validator(['hex_color' => 'rgb(0,0,255)'], $rule)->passes());
+        $this->assertTrue(validator(['hex_color' => '#000000'], $rule)->passes());
+    }
+}

--- a/tests/HexColorTest.php
+++ b/tests/HexColorTest.php
@@ -13,9 +13,11 @@ class HexColorTest extends TestCase
         $rule = ['hex_color' => [new HexColor()]];
 
         $this->assertTrue(validator(['hex_color' => '#f0f0f0'], $rule)->passes());
-        $this->assertFalse(validator(['hex_color' => '#f0f0f0ff'], $rule)->passes());
+        $this->assertTrue(validator(['hex_color' => '#fff'], $rule)->passes());
+        $this->assertTrue(validator(['hex_color' => '#00ff0080'], $rule)->passes());
         $this->assertFalse(validator(['hex_color' => 'f0f0f0'], $rule)->passes());
         $this->assertFalse(validator(['hex_color' => 'rgb(0,0,255)'], $rule)->passes());
         $this->assertTrue(validator(['hex_color' => '#000000'], $rule)->passes());
+        $this->assertTrue(validator(['hex_color' => '#ssssss'], $rule)->passes());
     }
 }

--- a/tests/HexColorTest.php
+++ b/tests/HexColorTest.php
@@ -15,9 +15,10 @@ class HexColorTest extends TestCase
         $this->assertTrue(validator(['hex_color' => '#f0f0f0'], $rule)->passes());
         $this->assertTrue(validator(['hex_color' => '#fff'], $rule)->passes());
         $this->assertTrue(validator(['hex_color' => '#00ff0080'], $rule)->passes());
+        $this->assertFalse(validator(['hex_color' => '#00ff00ff'], $rule)->passes());
         $this->assertFalse(validator(['hex_color' => 'f0f0f0'], $rule)->passes());
         $this->assertFalse(validator(['hex_color' => 'rgb(0,0,255)'], $rule)->passes());
         $this->assertTrue(validator(['hex_color' => '#000000'], $rule)->passes());
-        $this->assertTrue(validator(['hex_color' => '#ssssss'], $rule)->passes());
+        $this->assertFalse(validator(['hex_color' => '#0f0f'], $rule)->passes());
     }
 }


### PR DESCRIPTION
This PR aims to add hex-code color validation.

Simple to use as :
```php
use Axiom\Rules\HexColor;


$request->validate([
   'myColor' => [new HexColor]
]);
```

All hex colors should start with `#` like `#000`